### PR TITLE
Bump vscode dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,15 @@
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -268,6 +277,12 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
             "dev": true
         },
         "buffer-from": {
@@ -830,19 +845,18 @@
             "dev": true
         },
         "event-stream": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+            "version": "3.3.4",
+            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "^0.1.1",
-                "flatmap-stream": "^0.1.0",
-                "from": "^0.1.7",
-                "map-stream": "0.0.7",
-                "pause-stream": "^0.0.11",
-                "split": "^1.0.1",
-                "stream-combiner": "^0.2.2",
-                "through": "^2.3.8"
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -856,7 +870,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -1005,11 +1019,15 @@
                 "write": "^0.2.1"
             }
         },
-        "flatmap-stream": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-            "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-            "dev": true
+        "flush-write-stream": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
+            }
         },
         "for-in": {
             "version": "1.0.2",
@@ -1048,6 +1066,16 @@
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
+        },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1197,7 +1225,7 @@
                 },
                 "string_decoder": {
                     "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 },
@@ -1304,7 +1332,7 @@
                 },
                 "string_decoder": {
                     "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 },
@@ -1321,12 +1349,12 @@
             }
         },
         "gulp-remote-src-vscode": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
-            "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
+            "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.4",
+                "event-stream": "3.3.4",
                 "node.extend": "^1.1.2",
                 "request": "^2.79.0",
                 "through2": "^2.0.3",
@@ -1400,12 +1428,12 @@
             }
         },
         "gulp-symdest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
-            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.1.tgz",
+            "integrity": "sha512-UHd3MokfIN7SrFdsbV5uZTwzBpL0ZSTu7iq98fuDqBGZ0dlHxgbQBJwfd6qjCW83snkQ3Hz9IY4sMRMz2iTq7w==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
+                "event-stream": "3.3.4",
                 "mkdirp": "^0.5.1",
                 "queue": "^3.1.0",
                 "vinyl-fs": "^2.4.3"
@@ -1450,16 +1478,16 @@
             }
         },
         "gulp-vinyl-zip": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
-            "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
+            "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
+                "event-stream": "3.3.4",
                 "queue": "^4.2.1",
                 "through2": "^2.0.3",
                 "vinyl": "^2.0.2",
-                "vinyl-fs": "^2.0.0",
+                "vinyl-fs": "^3.0.3",
                 "yauzl": "^2.2.1",
                 "yazl": "^2.2.1"
             },
@@ -1476,13 +1504,56 @@
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
+                "glob-stream": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+                    "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+                    "dev": true,
+                    "requires": {
+                        "extend": "^3.0.0",
+                        "glob": "^7.1.1",
+                        "glob-parent": "^3.1.0",
+                        "is-negated-glob": "^1.0.0",
+                        "ordered-read-streams": "^1.0.0",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.1.5",
+                        "remove-trailing-separator": "^1.0.1",
+                        "to-absolute-glob": "^2.0.0",
+                        "unique-stream": "^2.0.2"
+                    }
+                },
+                "is-valid-glob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+                    "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+                    "dev": true
+                },
+                "ordered-read-streams": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+                    "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.0.1"
+                    }
+                },
                 "queue": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.0.tgz",
-                    "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
+                    "version": "4.5.1",
+                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
+                    "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
                     "dev": true,
                     "requires": {
                         "inherits": "~2.0.0"
+                    }
+                },
+                "to-absolute-glob": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+                    "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+                    "dev": true,
+                    "requires": {
+                        "is-absolute": "^1.0.0",
+                        "is-negated-glob": "^1.0.0"
                     }
                 },
                 "vinyl": {
@@ -1498,6 +1569,31 @@
                         "remove-trailing-separator": "^1.0.1",
                         "replace-ext": "^1.0.0"
                     }
+                },
+                "vinyl-fs": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+                    "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+                    "dev": true,
+                    "requires": {
+                        "fs-mkdirp-stream": "^1.0.0",
+                        "glob-stream": "^6.1.0",
+                        "graceful-fs": "^4.0.0",
+                        "is-valid-glob": "^1.0.0",
+                        "lazystream": "^1.0.0",
+                        "lead": "^1.0.0",
+                        "object.assign": "^4.0.4",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.3.3",
+                        "remove-bom-buffer": "^3.0.0",
+                        "remove-bom-stream": "^1.2.0",
+                        "resolve-options": "^1.1.0",
+                        "through2": "^2.0.0",
+                        "to-through": "^2.0.0",
+                        "value-or-function": "^3.0.0",
+                        "vinyl": "^2.0.0",
+                        "vinyl-sourcemap": "^1.1.0"
+                    }
                 }
             }
         },
@@ -1508,39 +1604,13 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-            "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "6.5.5",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-                    "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-                    "dev": true
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
-                }
             }
         },
         "has": {
@@ -1651,6 +1721,16 @@
             "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
             "dev": true
         },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "requires": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1725,6 +1805,12 @@
             "requires": {
                 "is-extglob": "^2.1.0"
             }
+        },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
         },
         "is-number": {
             "version": "2.1.0",
@@ -1803,6 +1889,15 @@
                 "has": "^1.0.1"
             }
         },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
+        },
         "is-resolvable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -1830,6 +1925,15 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -1840,6 +1944,12 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
             "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "isarray": {
@@ -1957,6 +2067,15 @@
                 "readable-stream": "^2.0.5"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2024,9 +2143,9 @@
             "dev": true
         },
         "map-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+            "version": "0.1.0",
+            "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
         "math-random": {
@@ -2246,9 +2365,9 @@
             "dev": true
         },
         "node.extend": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.7.tgz",
-            "integrity": "sha512-7Firgqanbd7UtypwBezNTEuo9eHKtEXd+pD96Aj4wai6Q2vM1S38X+MZvR7sQv5E5pj2TZ9j0Am4dLfc6EvKsA==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3",
@@ -2274,6 +2393,15 @@
             "dev": true,
             "requires": {
                 "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "now-and-later": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
             }
         },
         "oauth-sign": {
@@ -2600,6 +2728,27 @@
             "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
             "dev": true
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2620,7 +2769,7 @@
         },
         "queue": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
@@ -2714,6 +2863,27 @@
             "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
             "dev": true
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -2768,7 +2938,7 @@
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
@@ -2796,6 +2966,15 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
             "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
             "dev": true
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
+            }
         },
         "restore-cursor": {
             "version": "2.0.0",
@@ -2931,9 +3110,9 @@
             "dev": true
         },
         "split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "version": "0.3.3",
+            "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
                 "through": "2"
@@ -2969,13 +3148,12 @@
             "dev": true
         },
         "stream-combiner": {
-            "version": "0.2.2",
-            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+            "version": "0.0.4",
+            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1",
-                "through": "~2.3.4"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -3011,7 +3189,7 @@
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
@@ -3145,6 +3323,15 @@
                 }
             }
         },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
+            }
+        },
         "tough-cookie": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -3197,6 +3384,12 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
             "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+            "dev": true
+        },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
             "dev": true
         },
         "unique-stream": {
@@ -3255,6 +3448,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -3337,22 +3536,65 @@
                 "vinyl": "^0.4.3"
             }
         },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
+            }
+        },
         "vscode": {
-            "version": "1.1.21",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.21.tgz",
-            "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
+            "version": "1.1.24",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.24.tgz",
+            "integrity": "sha512-X2rFkk4OCYMmcIP/9uFvhvcmRB+J9te4d872Tup56Miax0h1O0o6WzsxyRog+V91yphdCgDmBbxsvjziEhxPkg==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2",
                 "gulp-chmod": "^2.0.0",
                 "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.0",
-                "gulp-symdest": "^1.1.0",
+                "gulp-remote-src-vscode": "^0.5.1",
+                "gulp-symdest": "^1.1.1",
                 "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.0",
+                "gulp-vinyl-zip": "^2.1.2",
                 "mocha": "^4.0.1",
-                "request": "^2.83.0",
+                "request": "^2.88.0",
                 "semver": "^5.4.1",
                 "source-map-support": "^0.5.0",
                 "url-parse": "^1.4.3",
@@ -3414,9 +3656,9 @@
             }
         },
         "yazl": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
-            "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "requires": {
                 "buffer-crc32": "~0.2.3"

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "typescript": "2.6.1",
-    "vscode": "1.1.21"
+    "vscode": "1.1.24"
   },
   "dependencies": {
     "enigma.js": "2.3.0",


### PR DESCRIPTION
Removes the security vulnerability in sub-dependency `event-stream`